### PR TITLE
Fix TaskEmbeddingSampler parallelism

### DIFF
--- a/launchers/trpo_point_embed.py
+++ b/launchers/trpo_point_embed.py
@@ -21,7 +21,7 @@ from sandbox.embed2learn.envs.multi_task_env import TfEnv
 from sandbox.embed2learn.envs.multi_task_env import normalize
 from sandbox.embed2learn.embeddings.utils import concat_spaces
 
-N_PARALLEL = 1  # TODO(gh/10): the sampler is broken for n_parallel > 1
+N_PARALLEL = 20
 
 TASKS = {
     '(-1, 0)': {'args': [], 'kwargs': {'goal': (-1, 0)}},


### PR DESCRIPTION
Moves the worker functions into global scope. They were originally class
methods on TaskEmbeddingSampler. The argument list provided to
multiprocessing was missing `self`. We could provide `self`, but there's no
need because the workers use only global and local scopes.

Note: the design of singleton_pool.run_each() assumes that target worker
method is not bound to a class. This should at least be guarded with an
`assert`

Fixes https://github.com/ryanjulian/embed2learn/issues/10
Opened https://github.com/ryanjulian/rllab/issues/27 to track the singleton_pool flaw.