### PR TITLE
Fix baseline optimization order

### DIFF
--- a/launchers/trpo_point_embed.py
+++ b/launchers/trpo_point_embed.py
@@ -21,18 +21,18 @@ from sandbox.embed2learn.envs.multi_task_env import TfEnv
 from sandbox.embed2learn.envs.multi_task_env import normalize
 from sandbox.embed2learn.embeddings.utils import concat_spaces
 
-N_PARALLEL = 20
+N_PARALLEL = 8
 
 TASKS = {
-    '(-1, 0)': {'args': [], 'kwargs': {'goal': (-1, 0)}},
-    '(1, 0)': {'args': [], 'kwargs': {'goal': (1, 0)}},
+    '(-3, 0)': {'args': [], 'kwargs': {'goal': (-3, 0)}},
+    '(3, 0)': {'args': [], 'kwargs': {'goal': (3, 0)}},
 } # yapf: disable
 TASK_NAMES = sorted(TASKS.keys())
 TASK_ARGS = [TASKS[t]['args'] for t in TASK_NAMES]
 TASK_KWARGS = [TASKS[t]['kwargs'] for t in TASK_NAMES]
 
 # Embedding params
-LATENT_LENGTH = 4
+LATENT_LENGTH = 8
 TRAJ_ENC_WINDOW = 5
 
 
@@ -74,7 +74,7 @@ def run_task(*_):
     policy = GaussianMLPPolicy(
         name="policy",
         env_spec=env_spec_embed,
-        hidden_sizes=(32, 32),
+        hidden_sizes=(64, 32),
         adaptive_std=True,  # Must be True for embedding learning
     )
 
@@ -82,14 +82,14 @@ def run_task(*_):
     task_embedding = GaussianMLPEmbedding(
         name="task_embedding",
         embedding_spec=task_embed_spec,
-        hidden_sizes=(32, 32),
+        hidden_sizes=(64, 64),
         adaptive_std=True,  # Must be True for embedding learning
     )
 
     traj_embedding = GaussianMLPEmbedding(
         name="traj_embedding",
         embedding_spec=traj_embed_spec,
-        hidden_sizes=(32, 32),
+        hidden_sizes=(64, 64),
         adaptive_std=True,  # Must be True for embedding learning
     )
 
@@ -103,10 +103,10 @@ def run_task(*_):
         trajectory_encoder=traj_embedding,
         batch_size=4000,
         max_path_length=100,
-        n_itr=200,
+        n_itr=1000,
         discount=0.99,
         step_size=0.01,
-        plot=False,
+        plot=True,
     )
     algo.train()
 
@@ -115,5 +115,5 @@ run_experiment_lite(
     run_task,
     exp_prefix='trpo_point_embed',
     n_parallel=N_PARALLEL,
-    plot=False,
+    plot=True,
 )


### PR DESCRIPTION
The baseline should be optimized *before* the policies, because the augmented
reward and return values depend on network parameters