### PR TITLE
Completion bonus for PointEnv

### DIFF
--- a/envs/point_env.py
+++ b/envs/point_env.py
@@ -6,13 +6,16 @@ import pygame
 from rllab.core.serializable import Serializable
 from rllab.envs.base import Env, Step
 from rllab.misc.overrides import overrides
-
 from rllab.spaces.box import Box
 
 MAX_SHOWN_TRACES = 10
-
-TRACE_COLORS = [(80, 150, 0), (100, 180, 10), (100, 210, 30), (140, 230, 50),
-                (180, 250, 150)]
+TRACE_COLORS = [
+    (80, 150, 0),
+    (100, 180, 10),
+    (100, 210, 30),
+    (140, 230, 50),
+    (180, 250, 150)
+] # yapf: disable
 BRIGHT_COLOR = (200, 200, 200)
 DARK_COLOR = (150, 150, 150)
 
@@ -42,19 +45,21 @@ class PointEnv(Env, Serializable):
 
     def reset(self):
         self._point = np.zeros_like(self._goal)
-        observation = np.copy(self._point)
         self._traces.append([])
-        return observation
+        return np.copy(self._point)
 
     def step(self, action):
         self._point = self._point + action
-        x, y = self._point
-        self._traces[-1].append((x, y))
-        goal_x, goal_y = self._goal
-        reward = -np.linalg.norm(self._point - self._goal)
+        self._traces[-1].append(tuple(self._point))
+
         done = np.linalg.norm(self._point - self._goal, ord=np.inf) < 0.1
-        next_observation = np.copy(self._point)
-        return Step(observation=next_observation, reward=reward, done=done)
+        reward = -np.linalg.norm(self._point - self._goal)
+
+        # completion bonus
+        if done:
+            reward = 20.0
+
+        return Step(observation=np.copy(self._point), reward=reward, done=done)
 
     def _to_screen(self, position):
         return (int(self.screen_width / 2 + position[0] * self.zoom),

--- a/launchers/trpo_point_embed.py
+++ b/launchers/trpo_point_embed.py
@@ -1,19 +1,16 @@
-import multiprocessing as mp
 import numpy as np
 
 from rllab.baselines.linear_feature_baseline import LinearFeatureBaseline
-from rllab.envs.normalized_env import normalize
-from rllab.misc.instrument import stub, run_experiment_lite
+from rllab.misc.instrument import run_experiment_lite
+from rllab.misc.ext import set_seed
 from rllab.envs.env_spec import EnvSpec
 
-from sandbox.rocky.tf.algos.trpo import TRPO
 from sandbox.rocky.tf.policies.gaussian_mlp_policy import GaussianMLPPolicy
 from sandbox.rocky.tf.envs.base import TfEnv
 from sandbox.rocky.tf.spaces.box import Box
 
 from sandbox.embed2learn.algos.trpo_task_embedding import TRPOTaskEmbedding
 from sandbox.embed2learn.embeddings.gaussian_mlp_embedding import GaussianMLPEmbedding
-from sandbox.embed2learn.embeddings.one_hot_embedding import OneHotEmbedding
 from sandbox.embed2learn.embeddings.embedding_spec import EmbeddingSpec
 from sandbox.embed2learn.envs.point_env import PointEnv
 from sandbox.embed2learn.envs.multi_task_env import MultiTaskEnv
@@ -21,7 +18,7 @@ from sandbox.embed2learn.envs.multi_task_env import TfEnv
 from sandbox.embed2learn.envs.multi_task_env import normalize
 from sandbox.embed2learn.embeddings.utils import concat_spaces
 
-N_PARALLEL = 8
+N_PARALLEL = 16
 
 TASKS = {
     '(-3, 0)': {'args': [], 'kwargs': {'goal': (-3, 0)}},
@@ -37,6 +34,8 @@ TRAJ_ENC_WINDOW = 5
 
 
 def run_task(*_):
+    set_seed(0)
+
     # Environment
     env = TfEnv(
         normalize(
@@ -103,10 +102,10 @@ def run_task(*_):
         trajectory_encoder=traj_embedding,
         batch_size=4000,
         max_path_length=100,
-        n_itr=1000,
+        n_itr=1100,
         discount=0.99,
         step_size=0.01,
-        plot=True,
+        plot=False,
     )
     algo.train()
 
@@ -115,5 +114,5 @@ run_experiment_lite(
     run_task,
     exp_prefix='trpo_point_embed',
     n_parallel=N_PARALLEL,
-    plot=True,
+    plot=False,
 )


### PR DESCRIPTION
Adding a completion bonus to PointEnv significantly reduces improves stability and rise time.

orange - no completion bonus
green - 10.0 (I used 20 for some margin)
red - 100.0

I did not show 1000 because it messed with the graph scales, but it has similar improvements to 10 and 100 while significantly increasing the variance of returns.

<img width="369" alt="screen shot 2018-03-30 at 7 17 52 pm" src="https://user-images.githubusercontent.com/1376219/38158934-e58c62d8-3452-11e8-86fe-2a8597f68514.png">
<img width="384" alt="screen shot 2018-03-30 at 7 18 02 pm" src="https://user-images.githubusercontent.com/1376219/38158940-e80a63e8-3452-11e8-948f-b66dea3d62dd.png">
<img width="365" alt="screen shot 2018-03-30 at 7 18 10 pm" src="https://user-images.githubusercontent.com/1376219/38158941-e939aac6-3452-11e8-88e6-d75bcbea7036.png">
<img width="372" alt="screen shot 2018-03-30 at 7 18 17 pm" src="https://user-images.githubusercontent.com/1376219/38158943-eaa06f4e-3452-11e8-8996-3aad1afd5cb6.png">
<img width="371" alt="screen shot 2018-03-30 at 7 18 24 pm" src="https://user-images.githubusercontent.com/1376219/38158944-ee47ba76-3452-11e8-8137-c2bf25ac3de5.png">




